### PR TITLE
[1주차/기본과제] 4가지 기능 구현 & 테스트 작성

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation(libs.spring.boot.starter.web)
     annotationProcessor(libs.spring.boot.configuration.processor)
     testImplementation(libs.spring.boot.starter.test)
+    testImplementation(libs.mockk)
 }
 
 // about source and compilation

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ junit = "5.9.3"
 assertj = "3.24.2"
 test_containers = "1.19.3"
 fixture_monkey = "1.0.13"
+mockk = "1.13.17"
 
 [plugins]
 kotlin_jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
@@ -51,5 +52,6 @@ micrometer_registry_prometheus = { module = "io.micrometer:micrometer-registry-p
 # test
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 spring_mockk = { module = "com.ninja-squad:springmockk", version.ref = "spring_mockk" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 [bundles]
 testcontainers_mysql = ["test_containers_mysql", "spring_boot_testcontainers", "test_containers_junit_jupiter","spring_boot_starter_test"]

--- a/src/main/kotlin/io/hhplus/tdd/database/PointHistoryTable.kt
+++ b/src/main/kotlin/io/hhplus/tdd/database/PointHistoryTable.kt
@@ -13,7 +13,7 @@ class PointHistoryTable {
     private var cursor: Long = 1L
 
     fun insert(
-        id: Long,
+        userId: Long,
         amount: Long,
         transactionType: TransactionType,
         updateMillis: Long,
@@ -21,7 +21,7 @@ class PointHistoryTable {
         Thread.sleep(Math.random().toLong() * 300L)
         val history = PointHistory(
             id = cursor++,
-            userId = id,
+            userId = userId,
             amount = amount,
             type = transactionType,
             timeMillis = updateMillis,

--- a/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.*
 @RestController
 @RequestMapping("/point")
 class PointController(
+    private val pointTransactionManger: PointTransactionManager,
     private val pointService: PointService,
     private val historyService: PointHistoryService,
 ) {
@@ -23,16 +24,12 @@ class PointController(
     ): List<PointHistory> =
         historyService.getAllByUser(id)
 
-    /**
-     * TODO - 특정 유저의 포인트를 충전하는 기능을 작성해주세요.
-     */
     @PatchMapping("{id}/charge")
     fun charge(
         @PathVariable id: Long,
         @RequestBody amount: Long,
-    ): UserPoint {
-        return UserPoint(0, 0, 0)
-    }
+    ): UserPoint =
+        pointTransactionManger.charge(userId = id, amount = amount)
 
     /**
      * TODO - 특정 유저의 포인트를 사용하는 기능을 작성해주세요.

--- a/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
@@ -31,14 +31,9 @@ class PointController(
     ): UserPoint =
         pointTransactionManger.charge(userId = id, amount = amount)
 
-    /**
-     * TODO - 특정 유저의 포인트를 사용하는 기능을 작성해주세요.
-     */
     @PatchMapping("{id}/use")
     fun use(
         @PathVariable id: Long,
         @RequestBody amount: Long,
-    ): UserPoint {
-        return UserPoint(0, 0, 0)
-    }
+    ): UserPoint = pointTransactionManger.use(userId = id, amount = amount)
 }

--- a/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/point")
 class PointController(
     private val pointService: PointService,
+    private val historyService: PointHistoryService,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(javaClass)
 
@@ -16,15 +17,11 @@ class PointController(
         @PathVariable id: Long,
     ): UserPoint = pointService.getPoint(id)
 
-    /**
-     * TODO - 특정 유저의 포인트 충전/이용 내역을 조회하는 기능을 작성해주세요.
-     */
     @GetMapping("{id}/histories")
     fun history(
         @PathVariable id: Long,
-    ): List<PointHistory> {
-        return emptyList()
-    }
+    ): List<PointHistory> =
+        historyService.getAllByUser(id)
 
     /**
      * TODO - 특정 유저의 포인트를 충전하는 기능을 작성해주세요.

--- a/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
@@ -6,18 +6,15 @@ import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/point")
-class PointController {
+class PointController(
+    private val pointService: PointService,
+) {
     private val logger: Logger = LoggerFactory.getLogger(javaClass)
 
-    /**
-     * TODO - 특정 유저의 포인트를 조회하는 기능을 작성해주세요.
-     */
     @GetMapping("{id}")
     fun point(
         @PathVariable id: Long,
-    ): UserPoint {
-        return UserPoint(0, 0, 0)
-    }
+    ): UserPoint = pointService.getPoint(id)
 
     /**
      * TODO - 특정 유저의 포인트 충전/이용 내역을 조회하는 기능을 작성해주세요.

--- a/src/main/kotlin/io/hhplus/tdd/point/PointHistoryService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointHistoryService.kt
@@ -1,0 +1,13 @@
+package io.hhplus.tdd.point
+
+import io.hhplus.tdd.database.PointHistoryTable
+import io.hhplus.tdd.database.UserPointTable
+import org.springframework.stereotype.Service
+
+@Service
+class PointHistoryService(
+    private val table: PointHistoryTable,
+) {
+    fun getAllByUser(userId: Long): List<PointHistory> =
+        table.selectAllByUserId(userId)
+}

--- a/src/main/kotlin/io/hhplus/tdd/point/PointHistoryService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointHistoryService.kt
@@ -1,7 +1,7 @@
 package io.hhplus.tdd.point
 
 import io.hhplus.tdd.database.PointHistoryTable
-import io.hhplus.tdd.database.UserPointTable
+import io.hhplus.tdd.point.command.CreateHistory
 import org.springframework.stereotype.Service
 
 @Service
@@ -10,4 +10,13 @@ class PointHistoryService(
 ) {
     fun getAllByUser(userId: Long): List<PointHistory> =
         table.selectAllByUserId(userId)
+
+    fun handle(command: CreateHistory) {
+        table.insert(
+            userId = command.userId,
+            amount = command.amount.value,
+            transactionType = command.transactionType,
+            updateMillis = command.updateMillis,
+        )
+    }
 }

--- a/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
@@ -1,12 +1,23 @@
 package io.hhplus.tdd.point
 
 import io.hhplus.tdd.database.UserPointTable
+import io.hhplus.tdd.point.command.ChargePoint
+import io.hhplus.tdd.point.command.PointAmount
 import org.springframework.stereotype.Service
 
 @Service
 class PointService(
     private val table: UserPointTable,
 ) {
+    fun handle(command: ChargePoint): UserPoint {
+        val userPoint = table.selectById(command.userId)
+        val totalAmount = (command.amount.value + userPoint.point).also { it.verifyAmount() }
+        return table.insertOrUpdate(command.userId, totalAmount)
+    }
+
     fun getPoint(id: Long): UserPoint =
         table.selectById(id)
+
+    private fun Long.verifyAmount(): PointAmount = PointAmount(this)
+
 }

--- a/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
@@ -1,0 +1,12 @@
+package io.hhplus.tdd.point
+
+import io.hhplus.tdd.database.UserPointTable
+import org.springframework.stereotype.Service
+
+@Service
+class PointService(
+    private val table: UserPointTable,
+) {
+    fun getPoint(id: Long): UserPoint =
+        table.selectById(id)
+}

--- a/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
@@ -3,21 +3,27 @@ package io.hhplus.tdd.point
 import io.hhplus.tdd.database.UserPointTable
 import io.hhplus.tdd.point.command.ChargePoint
 import io.hhplus.tdd.point.command.PointAmount
+import io.hhplus.tdd.point.command.UsePoint
 import org.springframework.stereotype.Service
 
 @Service
 class PointService(
     private val table: UserPointTable,
 ) {
-    fun handle(command: ChargePoint): UserPoint {
-        val userPoint = table.selectById(command.userId)
-        val totalAmount = (command.amount.value + userPoint.point).also { it.verifyAmount() }
-        return table.insertOrUpdate(command.userId, totalAmount)
-    }
-
     fun getPoint(id: Long): UserPoint =
         table.selectById(id)
 
-    private fun Long.verifyAmount(): PointAmount = PointAmount(this)
+    fun handle(command: ChargePoint): UserPoint {
+        val userPoint = table.selectById(command.userId)
+        val totalAmount = (userPoint.point + command.amount.value).also { it.verifyAmount() }
+        return table.insertOrUpdate(command.userId, totalAmount)
+    }
 
+    fun handle(command: UsePoint): UserPoint {
+        val userPoint = table.selectById(command.userId)
+        val totalAmount =(userPoint.point - command.amount.value).also { it.verifyAmount() }
+        return table.insertOrUpdate(command.userId, totalAmount)
+    }
+
+    private fun Long.verifyAmount(): PointAmount = PointAmount(this)
 }

--- a/src/main/kotlin/io/hhplus/tdd/point/PointTransactionManager.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointTransactionManager.kt
@@ -1,0 +1,26 @@
+package io.hhplus.tdd.point
+
+import io.hhplus.tdd.point.command.ChargePoint
+import io.hhplus.tdd.point.command.CreateHistory
+import io.hhplus.tdd.point.command.PointAmount
+import org.springframework.stereotype.Service
+
+@Service
+class PointTransactionManager(
+    private val pointService: PointService,
+    private val historyService: PointHistoryService,
+) {
+    fun charge(userId: Long, amount: Long): UserPoint {
+        val amount = PointAmount(amount)
+        val userPoint = pointService.handle(ChargePoint(userId, amount))
+        historyService.handle(
+            CreateHistory(
+                userId = userId,
+                amount = amount,
+                transactionType = TransactionType.CHARGE,
+                updateMillis = userPoint.updateMillis,
+            )
+        )
+        return userPoint
+    }
+}

--- a/src/main/kotlin/io/hhplus/tdd/point/PointTransactionManager.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointTransactionManager.kt
@@ -3,6 +3,7 @@ package io.hhplus.tdd.point
 import io.hhplus.tdd.point.command.ChargePoint
 import io.hhplus.tdd.point.command.CreateHistory
 import io.hhplus.tdd.point.command.PointAmount
+import io.hhplus.tdd.point.command.UsePoint
 import org.springframework.stereotype.Service
 
 @Service
@@ -18,6 +19,20 @@ class PointTransactionManager(
                 userId = userId,
                 amount = amount,
                 transactionType = TransactionType.CHARGE,
+                updateMillis = userPoint.updateMillis,
+            )
+        )
+        return userPoint
+    }
+
+    fun use(userId: Long, amount: Long): UserPoint {
+        val amount = PointAmount(amount)
+        val userPoint = pointService.handle(UsePoint(userId, amount))
+        historyService.handle(
+            CreateHistory(
+                userId = userId,
+                amount = amount,
+                transactionType = TransactionType.USE,
                 updateMillis = userPoint.updateMillis,
             )
         )

--- a/src/main/kotlin/io/hhplus/tdd/point/command/ChargePoint.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/command/ChargePoint.kt
@@ -1,0 +1,6 @@
+package io.hhplus.tdd.point.command
+
+data class ChargePoint (
+    val userId: Long,
+    val amount: PointAmount,
+)

--- a/src/main/kotlin/io/hhplus/tdd/point/command/CreateHistory.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/command/CreateHistory.kt
@@ -1,0 +1,10 @@
+package io.hhplus.tdd.point.command
+
+import io.hhplus.tdd.point.TransactionType
+
+data class CreateHistory (
+    val userId: Long,
+    val amount: PointAmount,
+    val transactionType: TransactionType,
+    val updateMillis: Long,
+)

--- a/src/main/kotlin/io/hhplus/tdd/point/command/PointAmount.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/command/PointAmount.kt
@@ -1,0 +1,15 @@
+package io.hhplus.tdd.point.command
+
+@JvmInline
+value class PointAmount (
+    val value: Long,
+) {
+    init {
+        require(value in 0..MAX_POINT) { "point amount must be in range 0 to $MAX_POINT" }
+    }
+
+    companion object {
+        const val MAX_POINT = 10_000L
+    }
+}
+

--- a/src/main/kotlin/io/hhplus/tdd/point/command/UsePoint.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/command/UsePoint.kt
@@ -1,0 +1,6 @@
+package io.hhplus.tdd.point.command
+
+data class UsePoint (
+    val userId: Long,
+    val amount: PointAmount,
+)

--- a/src/test/kotlin/io/hhplus/tdd/database/PointHistoryTableTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/database/PointHistoryTableTest.kt
@@ -1,0 +1,99 @@
+package io.hhplus.tdd.database
+
+import io.hhplus.tdd.point.TransactionType
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIterable
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+
+class PointHistoryTableTest {
+
+    @Nested
+    @DisplayName("포인트 내역 조회")
+    inner class SelectAllByUserIdTest {
+        @Test
+        fun `해당 유저의 내역이 있는 경우 모든 내역을 조회해 반환한다`() {
+            val table = PointHistoryTable()
+            val userId = 1L
+            val historyData = listOf(
+                Triple(1L, TransactionType.USE, System.currentTimeMillis()),
+                Triple(2L, TransactionType.CHARGE, System.currentTimeMillis()),
+                Triple(3L, TransactionType.USE, System.currentTimeMillis()),
+            )
+            historyData.forEach { (amount, type, time) ->
+                table.insert(userId, amount, type, time)
+            }
+            // other user
+            table.insert(2L, 100, TransactionType.CHARGE, System.currentTimeMillis())
+
+            val result = table.selectAllByUserId(userId)
+
+            assertThat(result).allSatisfy {
+                val data = Triple(it.amount, it.type, it.timeMillis)
+                assertThat(historyData).contains(data)
+            }
+        }
+
+        @Test
+        fun `해당 유저의 내역이 있는 경우 내역은 저장된 순서대로 반환된다`() {
+            val table = PointHistoryTable()
+            val userId = 1L
+            val historyIdsInOrder =
+            List(3) {
+                val historyId = table.insert(userId, 100, TransactionType.CHARGE, System.currentTimeMillis()).id
+                historyId
+            }
+
+            val result = table.selectAllByUserId(userId)
+
+            assertThatIterable(result).extracting("id").isEqualTo(historyIdsInOrder)
+        }
+
+        @Test
+        fun `전달 받은 id의 유저의 내역이 저장되어있지 않은 경우, 빈 리스트를 반환한다`() {
+            val table = PointHistoryTable()
+
+            val result = table.selectAllByUserId(1L)
+
+            assertThat(result).isEmpty()
+        }
+    }
+
+    @Nested
+    @DisplayName("포인트 내역 생성")
+    inner class InsertTest {
+        @Test
+        fun `포인트 내역을 생성한다`() {
+            val table = PointHistoryTable()
+            val userId = 3L
+            val amount = 1000L
+            val transactionType = TransactionType.CHARGE
+            val updateMillis = System.currentTimeMillis()
+
+            val result = table.insert(
+                userId = userId,
+                amount = amount,
+                transactionType = transactionType,
+                updateMillis = updateMillis
+            )
+
+            assertAll(
+                { assertThat(result.userId).isEqualTo(userId) },
+                { assertThat(result.amount).isEqualTo(amount) },
+                { assertThat(result.type).isEqualTo(transactionType) },
+                { assertThat(result.timeMillis).isEqualTo(updateMillis) }
+            )
+            val allSaved = table.selectAllByUserId(userId)
+            assertThat(allSaved.size).isEqualTo(1)
+            val saved = allSaved.first()
+            assertAll(
+                { assertThat(saved.userId).isEqualTo(userId) },
+                { assertThat(saved.amount).isEqualTo(amount) },
+                { assertThat(saved.type).isEqualTo(transactionType) },
+                { assertThat(saved.timeMillis).isEqualTo(updateMillis) }
+            )
+        }
+    }
+}

--- a/src/test/kotlin/io/hhplus/tdd/database/UserPointTableTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/database/UserPointTableTest.kt
@@ -1,0 +1,80 @@
+package io.hhplus.tdd.database
+
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+
+class UserPointTableTest {
+
+    @Nested
+    @DisplayName("유저의 모든 내역 조회")
+    inner class SelectUserPointTest {
+
+        @Test
+        fun `전달 받은 id로 유저의 포인트를 조회해 반환한다`() {
+            val table = UserPointTable()
+            val id = (1L..10L).random()
+            val point = (1L..10L).random()
+            table.insertOrUpdate(id, point)
+
+            val result = table.selectById(id)
+
+            assertAll(
+                { assert(result.id == id) },
+                { assert(result.point == point) }
+            )
+        }
+
+        @Test
+        fun `전달 받은 id를 가진 유저의 포인트가 저장되어있지 않은 경우, 포인트를 0으로 반환한다`() {
+            val id = 1L
+            val table = UserPointTable()
+
+            val result = table.selectById(id)
+
+            assertAll(
+                { assertThat(result.id).isEqualTo(id) },
+                { assertThat(result.point).isEqualTo(0) }
+            )
+        }
+    }
+
+    @Nested
+    @DisplayName("유저 포인트 생성 혹은 업데이트")
+    inner class InsertOrUpdatePointTest {
+        @Test
+        fun `전달 받은 id의 유저 포인트가 저장되어 있는 경우, 해당 정보로 변경된다`() {
+            val table = UserPointTable()
+            val id = (1L..10L).random()
+            val point = (1L..10L).random()
+            table.insertOrUpdate(id, point)
+
+            val updatedPoint = point + 10
+            table.insertOrUpdate(id, updatedPoint)
+
+            val result = table.selectById(id)
+            assertAll(
+                { assertThat(result.id).isEqualTo(id) },
+                { assertThat(result.point).isEqualTo(updatedPoint) }
+            )
+        }
+
+        @Test
+        fun `전달 받은 id의 유저 포인트가 저장되어 있지 않은 경우, 해당 정보로 포인트를 생성한다`() {
+            val table = UserPointTable()
+            val id = (1L..10L).random()
+            val point = (1L..10L).random()
+
+            table.insertOrUpdate(id, point)
+
+            val result = table.selectById(id)
+            assertAll(
+                { assertThat(result.id).isEqualTo(id) },
+                { assertThat(result.point).isEqualTo(point) }
+            )
+        }
+    }
+}

--- a/src/test/kotlin/io/hhplus/tdd/point/PointHistoryServiceTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointHistoryServiceTest.kt
@@ -1,33 +1,60 @@
 package io.hhplus.tdd.point
 
 import io.hhplus.tdd.database.PointHistoryTable
+import io.hhplus.tdd.point.command.CreateHistory
 import io.mockk.coEvery
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(MockKExtension::class)
 class PointHistoryServiceTest {
-    @MockK
+    @MockK(relaxed = true)
     private lateinit var table: PointHistoryTable
 
     @InjectMockKs
     private lateinit var service: PointHistoryService
 
-    @Test
-    fun `전달 받은 유저 id로 유저의 히스토리를 조회해 반환한다`() {
-        val history = PointMock.pointHistory()
-        val userHistories = listOf(history)
-        val userId = history.userId
-        coEvery { table.selectAllByUserId(userId) } returns userHistories
+    @Nested
+    @DisplayName("포인트 내역 조회")
+    inner class GetPointTest {
+        @Test
+        fun `전달 받은 id를 가진 유저의 포인트 내역를 조회해 반환한다`() {
+            val history = PointMock.pointHistory()
+            val userHistories = listOf(history)
+            val userId = history.userId
+            coEvery { table.selectAllByUserId(userId) } returns userHistories
 
-        val result = service.getAllByUser(userId)
+            val result = service.getAllByUser(userId)
 
-        verify { table.selectAllByUserId(userId) }
-        assertThat(result).isEqualTo(userHistories)
+            verify { table.selectAllByUserId(userId) }
+            assertThat(result).isEqualTo(userHistories)
+        }
+    }
+
+    @Nested
+    @DisplayName("포인트 내역 생성")
+    inner class CreateHistoryTest {
+        @Test
+        fun `전달 받은 유저 id로 유저의 히스토리를 조회해 반환한다`() {
+            val history = PointMock.pointHistory()
+            val userId = history.userId
+            val command = CreateHistory(
+                userId = userId,
+                amount = PointMock.pointAmount(),
+                transactionType = TransactionType.entries.random(),
+                updateMillis = System.currentTimeMillis()
+            )
+
+            service.handle(command)
+
+            verify { table.insert(command.userId, command.amount.value, command.transactionType, command.updateMillis) }
+        }
     }
 }

--- a/src/test/kotlin/io/hhplus/tdd/point/PointHistoryServiceTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointHistoryServiceTest.kt
@@ -1,0 +1,33 @@
+package io.hhplus.tdd.point
+
+import io.hhplus.tdd.database.PointHistoryTable
+import io.mockk.coEvery
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class PointHistoryServiceTest {
+    @MockK
+    private lateinit var table: PointHistoryTable
+
+    @InjectMockKs
+    private lateinit var service: PointHistoryService
+
+    @Test
+    fun `전달 받은 유저 id로 유저의 히스토리를 조회해 반환한다`() {
+        val history = PointMock.pointHistory()
+        val userHistories = listOf(history)
+        val userId = history.userId
+        coEvery { table.selectAllByUserId(userId) } returns userHistories
+
+        val result = service.getAllByUser(userId)
+
+        verify { table.selectAllByUserId(userId) }
+        assertThat(result).isEqualTo(userHistories)
+    }
+}

--- a/src/test/kotlin/io/hhplus/tdd/point/PointMock.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointMock.kt
@@ -1,11 +1,17 @@
 package io.hhplus.tdd.point
 
+import io.hhplus.tdd.point.command.PointAmount
+
 object PointMock {
     fun userPoint(
         id: Long = (0L..10L).random(),
         point: Long = (0..10L).random(),
         updateMillis: Long = System.currentTimeMillis()
     ): UserPoint = UserPoint(id, point, updateMillis)
+
+    fun pointAmount(
+        value: Long = (0..10L).random()
+    ): PointAmount = PointAmount(value)
 
     fun pointHistory(
         id: Long = (0L..10L).random(),

--- a/src/test/kotlin/io/hhplus/tdd/point/PointMock.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointMock.kt
@@ -1,0 +1,17 @@
+package io.hhplus.tdd.point
+
+object PointMock {
+    fun userPoint(
+        id: Long = (0L..10L).random(),
+        point: Long = (0..10L).random(),
+        updateMillis: Long = System.currentTimeMillis()
+    ): UserPoint = UserPoint(id, point, updateMillis)
+
+    fun pointHistory(
+        id: Long = (0L..10L).random(),
+        userId: Long = (1L..10L).random(),
+        type: TransactionType = TransactionType.USE,
+        point: Long = (0..10L).random(),
+        updateMillis: Long = System.currentTimeMillis()
+    ): PointHistory = PointHistory(id, userId, type, point, updateMillis)
+}

--- a/src/test/kotlin/io/hhplus/tdd/point/PointServiceTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointServiceTest.kt
@@ -7,6 +7,8 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -14,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 class PointServiceTest {
     @MockK
     private lateinit var table: UserPointTable
+
     @InjectMockKs
     private lateinit var service: PointService
 

--- a/src/test/kotlin/io/hhplus/tdd/point/PointServiceTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointServiceTest.kt
@@ -1,0 +1,31 @@
+package io.hhplus.tdd.point
+
+import io.hhplus.tdd.database.UserPointTable
+import io.mockk.coEvery
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class PointServiceTest {
+    @MockK
+    private lateinit var table: UserPointTable
+    @InjectMockKs
+    private lateinit var service: PointService
+
+    @Test
+    fun `전달 받은 id로 테이블에서 유저의 포인트를 조회해 반환한다`() {
+        val id = (1L..10L).random()
+        val userPoint = UserPoint(id = id, point = (0L..10L).random(), updateMillis = System.currentTimeMillis())
+        coEvery { service.getPoint(id) } returns userPoint
+
+        val result = service.getPoint(id)
+
+        verify { table.selectById(id) }
+        assertThat(result).isEqualTo(userPoint)
+    }
+}

--- a/src/test/kotlin/io/hhplus/tdd/point/PointServiceTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointServiceTest.kt
@@ -1,34 +1,88 @@
 package io.hhplus.tdd.point
 
 import io.hhplus.tdd.database.UserPointTable
+import io.hhplus.tdd.point.command.ChargePoint
+import io.hhplus.tdd.point.command.PointAmount
 import io.mockk.coEvery
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.verify
+import io.mockk.verifyOrder
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(MockKExtension::class)
 class PointServiceTest {
-    @MockK
+    @MockK(relaxed = true)
     private lateinit var table: UserPointTable
 
     @InjectMockKs
     private lateinit var service: PointService
 
-    @Test
-    fun `전달 받은 id로 테이블에서 유저의 포인트를 조회해 반환한다`() {
-        val id = (1L..10L).random()
-        val userPoint = UserPoint(id = id, point = (0L..10L).random(), updateMillis = System.currentTimeMillis())
-        coEvery { service.getPoint(id) } returns userPoint
+    @Nested
+    @DisplayName("포인트 조회")
+    inner class GetPointTest {
+        @Test
+        fun `전달 받은 id로 유저의 포인트를 조회해 반환한다`() {
+            val id = (1L..10L).random()
+            val userPoint = UserPoint(id = id, point = (0L..10L).random(), updateMillis = System.currentTimeMillis())
+            coEvery { service.getPoint(id) } returns userPoint
 
-        val result = service.getPoint(id)
+            val result = service.getPoint(id)
 
-        verify { table.selectById(id) }
-        assertThat(result).isEqualTo(userPoint)
+            verify { table.selectById(id) }
+            assertThat(result).isEqualTo(userPoint)
+        }
+    }
+
+    @Nested
+    @DisplayName("포인트 충전")
+    inner class ChargePointTest {
+        @Test
+        fun `전달 받은 id로 유저의 포인트를 조회해 포인트를 합산해 저장한다`() {
+            val userPoint = PointMock.userPoint(point = 10L)
+            val id = userPoint.id
+            val command = ChargePoint(id, PointAmount(20L))
+            val expectPoint = 30L
+            coEvery { service.getPoint(id) } returns userPoint
+
+            service.handle(command)
+
+            verify {
+                table.selectById(id)
+                table.insertOrUpdate(id, expectPoint)
+            }
+        }
+
+        @Test
+        fun `반환된 포인트는 충전된 결과이다`() {
+            val userPoint = PointMock.userPoint()
+            val id = userPoint.id
+            val command = ChargePoint(id, PointAmount(20L))
+            val returnPoint = PointMock.userPoint()
+            coEvery { service.getPoint(id) } returns userPoint
+            coEvery { table.insertOrUpdate(id, any()) } returns returnPoint
+
+            val result = service.handle(command)
+
+            assertThat(result).isEqualTo(returnPoint)
+        }
+
+        @Test
+        fun `합산된 포인트가 최대 포인트를 초과할 경우 에러가 발생한다`() {
+            val userPoint = PointMock.userPoint(point = PointAmount.MAX_POINT)
+            val id = userPoint.id
+            val command = ChargePoint(id, PointAmount(20L))
+            coEvery { service.getPoint(id) } returns userPoint
+
+            assertThrows<IllegalArgumentException> {
+                service.handle(command)
+            }
+        }
     }
 }

--- a/src/test/kotlin/io/hhplus/tdd/point/PointTransactionMangerTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointTransactionMangerTest.kt
@@ -3,6 +3,7 @@ package io.hhplus.tdd.point
 import io.hhplus.tdd.point.command.ChargePoint
 import io.hhplus.tdd.point.command.CreateHistory
 import io.hhplus.tdd.point.command.PointAmount
+import io.hhplus.tdd.point.command.UsePoint
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
@@ -65,6 +66,51 @@ class PointTransactionMangerTest {
             every { pointService.handle(ofType(ChargePoint::class)) } returns returnPoint
 
             val result = manager.charge(1L, 100L)
+
+            assertThat(result).isEqualTo(returnPoint)
+        }
+    }
+
+    @Nested
+    @DisplayName("포인트 사용을 하면")
+    inner class UseTest {
+        @Test
+        fun `해당하는 유저 아이디에 대한 포인트를 사용한다`() {
+            val userId = (1..10).random().toLong()
+            val amount = (100..200).random().toLong()
+
+            manager.use(userId, amount)
+
+            verify { pointService.handle(UsePoint(userId, PointAmount(amount))) }
+        }
+
+        @Test
+        fun `해당하는 사용 내역을 생성한다`() {
+            val userId = (1..10).random().toLong()
+            val amount = (100..200).random().toLong()
+            val returnPoint = PointMock.userPoint(id = userId)
+            every { pointService.handle(ofType(UsePoint::class)) } returns returnPoint
+
+            manager.use(userId, amount)
+
+            verify {
+                historyService.handle(
+                    withArg<CreateHistory> {
+                        assertThat(it.userId).isEqualTo(userId)
+                        assertThat(it.amount).isEqualTo(PointAmount(amount))
+                        assertThat(it.transactionType).isEqualTo(TransactionType.USE)
+                        assertThat(it.updateMillis).isEqualTo(returnPoint.updateMillis)
+                    }
+                )
+            }
+        }
+
+        @Test
+        fun `사용 후 포인트가 반환된다`() {
+            val returnPoint = PointMock.userPoint()
+            every { pointService.handle(ofType(UsePoint::class)) } returns returnPoint
+
+            val result = manager.use(1L, 100L)
 
             assertThat(result).isEqualTo(returnPoint)
         }

--- a/src/test/kotlin/io/hhplus/tdd/point/PointTransactionMangerTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointTransactionMangerTest.kt
@@ -1,0 +1,72 @@
+package io.hhplus.tdd.point
+
+import io.hhplus.tdd.point.command.ChargePoint
+import io.hhplus.tdd.point.command.CreateHistory
+import io.hhplus.tdd.point.command.PointAmount
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class PointTransactionMangerTest {
+    @MockK(relaxed = true)
+    private lateinit var pointService: PointService
+
+    @MockK(relaxed = true)
+    private lateinit var historyService: PointHistoryService
+
+    @InjectMockKs
+    private lateinit var manager: PointTransactionManager
+
+    @Nested
+    @DisplayName("포인트 충전을 하면")
+    inner class ChargeTest {
+        @Test
+        fun `해당하는 유저 아이디에 대한 포인트를 충전한다`() {
+            val userId = (1..10).random().toLong()
+            val amount = (100..200).random().toLong()
+            manager.charge(userId, amount)
+
+            verify { pointService.handle(ChargePoint(userId, PointAmount(amount))) }
+        }
+
+        @Test
+        fun `해당하는 충전 내역을 생성한다`() {
+            val userId = (1..10).random().toLong()
+            val amount = (100..200).random().toLong()
+            val returnPoint = PointMock.userPoint(id = userId)
+            every { pointService.handle(ofType(ChargePoint::class)) } returns returnPoint
+
+            manager.charge(userId, amount)
+
+            verify {
+                historyService.handle(
+                    withArg<CreateHistory> {
+                        assertThat(it.userId).isEqualTo(userId)
+                        assertThat(it.amount).isEqualTo(PointAmount(amount))
+                        assertThat(it.transactionType).isEqualTo(TransactionType.CHARGE)
+                        assertThat(it.updateMillis).isEqualTo(returnPoint.updateMillis)
+                    }
+                )
+            }
+        }
+
+        @Test
+        fun `충전된 포인트가 반환된다`() {
+            val returnPoint = PointMock.userPoint()
+            every { pointService.handle(ofType(ChargePoint::class)) } returns returnPoint
+
+            val result = manager.charge(1L, 100L)
+
+            assertThat(result).isEqualTo(returnPoint)
+        }
+    }
+}

--- a/src/test/kotlin/io/hhplus/tdd/point/PointerControllerTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointerControllerTest.kt
@@ -7,6 +7,8 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -14,18 +16,41 @@ import org.junit.jupiter.api.extension.ExtendWith
 class PointerControllerTest {
     @MockK
     private lateinit var pointService: PointService
+    @MockK
+    private lateinit var historyService: PointHistoryService
     @InjectMockKs
     private lateinit var controller: PointController
 
-    @Test
-    fun `유저 포인트 조회 - 전달 받은 id로 서비스에서 유저의 포인트를 조회해 반환한다`() {
-        val id = (1L..10L).random()
-        val userPoint = UserPoint(id = id, point = (0L..10L).random(), updateMillis = System.currentTimeMillis())
-        coEvery { pointService.getPoint(id) } returns userPoint
+    @Nested
+    @DisplayName("유저 포인트 조회")
+    inner class GetPointTest{
+        @Test
+        fun `전달 받은 id로 서비스에서 유저의 포인트를 조회해 반환한다`() {
+            val userPoint = PointMock.userPoint()
+            val id = userPoint.id
+            coEvery { pointService.getPoint(id) } returns userPoint
 
-        val result = controller.point(id)
+            val result = controller.point(id)
 
-        verify { pointService.getPoint(id) }
-        assertThat(result).isEqualTo(userPoint)
+            verify { pointService.getPoint(id) }
+            assertThat(result).isEqualTo(userPoint)
+        }
+    }
+
+    @Nested
+    @DisplayName("포인트 내역 조회")
+    inner class GetHistoryTest{
+        @Test
+        fun `전달 받은 유저 id로 서비스에서 유저의 포인트 내역을 조회해 반환한다`() {
+            val history = PointMock.pointHistory()
+            val userId = history.userId
+            val userHistories = listOf(history)
+            coEvery { historyService.getAllByUser(userId) } returns userHistories
+
+            val result = controller.history(userId)
+
+            verify { historyService.getAllByUser(userId) }
+            assertThat(result).isEqualTo(userHistories)
+        }
     }
 }

--- a/src/test/kotlin/io/hhplus/tdd/point/PointerControllerTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointerControllerTest.kt
@@ -58,7 +58,7 @@ class PointerControllerTest {
 
     @Nested
     @DisplayName("포인트 충전")
-    inner class ChargeTest{
+    inner class ChargePointTest{
         @Test
         fun `전달 받은 id와 포인트로 해당 유저의 포인트를 충전해, 결과를 반환한다`() {
             val id = 1L
@@ -69,6 +69,23 @@ class PointerControllerTest {
             val result = controller.charge(id = id, amount)
 
             verify { pointTransactionManager.charge(id, amount) } 
+            assertThat(result).isEqualTo(userPoint)
+        }
+    }
+
+    @Nested
+    @DisplayName("포인트 사용")
+    inner class UsePointTest{
+        @Test
+        fun `전달 받은 id와 포인트로 해당 유저의 포인트를 사용한 후, 결과를 반환한다`() {
+            val id = 1L
+            val amount = 100L
+            val userPoint = PointMock.userPoint()
+            coEvery { pointTransactionManager.use(id, amount) } returns userPoint
+
+            val result = controller.use(id = id, amount)
+
+            verify { pointTransactionManager.use(id, amount) }
             assertThat(result).isEqualTo(userPoint)
         }
     }

--- a/src/test/kotlin/io/hhplus/tdd/point/PointerControllerTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointerControllerTest.kt
@@ -1,0 +1,31 @@
+package io.hhplus.tdd.point
+
+
+import io.mockk.coEvery
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class PointerControllerTest {
+    @MockK
+    private lateinit var pointService: PointService
+    @InjectMockKs
+    private lateinit var controller: PointController
+
+    @Test
+    fun `유저 포인트 조회 - 전달 받은 id로 서비스에서 유저의 포인트를 조회해 반환한다`() {
+        val id = (1L..10L).random()
+        val userPoint = UserPoint(id = id, point = (0L..10L).random(), updateMillis = System.currentTimeMillis())
+        coEvery { pointService.getPoint(id) } returns userPoint
+
+        val result = controller.point(id)
+
+        verify { pointService.getPoint(id) }
+        assertThat(result).isEqualTo(userPoint)
+    }
+}

--- a/src/test/kotlin/io/hhplus/tdd/point/PointerControllerTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointerControllerTest.kt
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.extension.ExtendWith
 @ExtendWith(MockKExtension::class)
 class PointerControllerTest {
     @MockK
+    private lateinit var pointTransactionManager: PointTransactionManager
+    @MockK
     private lateinit var pointService: PointService
     @MockK
     private lateinit var historyService: PointHistoryService
@@ -25,7 +27,7 @@ class PointerControllerTest {
     @DisplayName("유저 포인트 조회")
     inner class GetPointTest{
         @Test
-        fun `전달 받은 id로 서비스에서 유저의 포인트를 조회해 반환한다`() {
+        fun `전달 받은 id로 유저의 포인트를 조회해 반환한다`() {
             val userPoint = PointMock.userPoint()
             val id = userPoint.id
             coEvery { pointService.getPoint(id) } returns userPoint
@@ -41,7 +43,7 @@ class PointerControllerTest {
     @DisplayName("포인트 내역 조회")
     inner class GetHistoryTest{
         @Test
-        fun `전달 받은 유저 id로 서비스에서 유저의 포인트 내역을 조회해 반환한다`() {
+        fun `전달 받은 유저 id로 유저의 포인트 내역을 조회해 반환한다`() {
             val history = PointMock.pointHistory()
             val userId = history.userId
             val userHistories = listOf(history)
@@ -51,6 +53,23 @@ class PointerControllerTest {
 
             verify { historyService.getAllByUser(userId) }
             assertThat(result).isEqualTo(userHistories)
+        }
+    }
+
+    @Nested
+    @DisplayName("포인트 충전")
+    inner class ChargeTest{
+        @Test
+        fun `전달 받은 id와 포인트로 해당 유저의 포인트를 충전해, 결과를 반환한다`() {
+            val id = 1L
+            val amount = 100L
+            val userPoint = PointMock.userPoint()
+            coEvery { pointTransactionManager.charge(id, amount) } returns userPoint
+
+            val result = controller.charge(id = id, amount)
+
+            verify { pointTransactionManager.charge(id, amount) } 
+            assertThat(result).isEqualTo(userPoint)
         }
     }
 }

--- a/src/test/kotlin/io/hhplus/tdd/point/charge/PointAmountTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/charge/PointAmountTest.kt
@@ -1,0 +1,34 @@
+package io.hhplus.tdd.point.charge
+
+import io.hhplus.tdd.point.command.PointAmount
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class PointAmountTest {
+    @ParameterizedTest
+    @ValueSource(longs = [0L, 2L])
+    fun `0이상인 수는 포인트가 될 수 있다`(amount: Long) {
+        assertDoesNotThrow { PointAmount(amount) }
+    }
+
+    @Test
+    fun `0미만인 수로 포인트를 생성하려고 하면 IllegalArgumentException가 발생한다`() {
+        val amount = (-10L..-1L).random()
+
+        assertThrows<IllegalArgumentException> {
+            PointAmount(amount)
+        }
+    }
+
+    @Test
+    fun `포인트 최대값보다 큰 수로 포인트를 생성하려고 하면 IllegalArgumentException가 발생한다`() {
+        val amount = PointAmount.MAX_POINT + 1
+
+        assertThrows<IllegalArgumentException> {
+            PointAmount(amount)
+        }
+    }
+}

--- a/src/test/kotlin/io/hhplus/tdd/point/command/PointAmountTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/command/PointAmountTest.kt
@@ -1,6 +1,5 @@
-package io.hhplus.tdd.point.charge
+package io.hhplus.tdd.point.command
 
-import io.hhplus.tdd.point.command.PointAmount
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows


### PR DESCRIPTION
### **커밋 링크**

유저 포인트 조회: [b577a9d](https://github.com/alert-kim/plus-backend/pull/2/commits/b577a9d907aa4bfd67d11df6e1078d941105bc4c)
포인트 내역 조회: [7599f89](https://github.com/alert-kim/plus-backend/pull/2/commits/7599f891cb35c7a7d7999ecaf3e9a21e3a2a3711)
포인트 충전: [319e5ee](https://github.com/alert-kim/plus-backend/pull/2/commits/319e5ee67f2950507558f9254f0ffeb25ad8b922)
포인트 사용: [1c8a8df](https://github.com/alert-kim/plus-backend/pull/2/commits/1c8a8dfab7a3b1b58acd326f79feb483b2300423)

---
### **리뷰 포인트(질문)**
- `PointTransctionManagerTest`에서, `manager.use()`에 대한 테스트를 '해당하는 유저 아이디에 대한 포인트를 충전한다', '해당하는 충전 내역을 생성한다', '충전된 포인트가 반환된다' 3개의 테스트로 나눠 두었는데, 하나의 테스트에서 실행해도 모두 검증 가능한 영역 같습니다. 테스트의 의미를 구분하기 위해 나눴지만, 이런 테스트가 많아질 경우 테스트 실행 시간이 너무 길어질 것 같다는 걱정도 듭니다. 이렇게 테스트를 나누는 것에 대한 검토 부탁드립니다. 
- 테스트를 위해 랜덤값을 사용했습니다. (`PointMock` 사용) 
  - 포인트 조회시에, 아이디가 1L 인 경우 정상 응답이 되는지 테스트 하는 경우, (그럴 일은 없지만) 응답값이 아이디가 1L로 고정되 반환되도록 메서드가 구현되어 있을 것을 방지하기 위해, 랜덤값으로 테스트를 진행하도록 했습니다. 테스트 파라미터를 늘려서 2건으로 테스트 하는 것이 맞을지 (유저 아이디 1L, 2L) 이런 랜덤한 값에 대한 테스트가 적절한지 검토 부탁드립니다. 

---
### **이번주 KPT 회고**

### Keep
꾸준히 학습하고 있다 

### Problem
질문 사항 등을 좀 더 정리해서 말하는 연습이 필요해 보인다 

### Try
작심 삼일이 되지 않게 계속 꾸준히 학습하기 
